### PR TITLE
Small rearchitecture of the insides of the package manager to be more performant by removing nested subprocesses

### DIFF
--- a/src/Actions.py
+++ b/src/Actions.py
@@ -2,26 +2,30 @@
 import gi
 
 gi.require_version('Gtk', '3.0')
-from gi.repository import GLib, Gio, Gtk
-import sys, os, subprocess
+import sys, subprocess
 
-operation = sys.argv[1]
-package = sys.argv[2]
+class Action:
+    def __init__(self, package) -> None:
+        self.package = package
+        self.commands = {
+            "install": ["apt-get", "install", package, "-yq", "-o", "APT::Status-Fd=1"],
+            "remove": ["apt", "purge", package, "-yq"],
+            "make-default": ["update-alternatives", "--set", "java", package],
+            "update-alternatives-auto": ["update-alternatives", "--auto", "java"],
+            "update-and-remove": ["/bin/sh", "-c", "update-alternatives --auto java && apt purge " + package + " -yq"]
+        }
 
-commands = {
-    "install": ["apt-get", "install", package, "-yq", "-o", "APT::Status-Fd=1"],
-    "remove": ["apt", "purge", package, "-yq"],
-    "make-default": ["update-alternatives", "--set", "java", package],
-    "update-alternatives-auto": ["update-alternatives", "--auto", "java"],
-    "update-and-remove": ["/bin/sh", "-c", "update-alternatives --auto java && apt purge " + package + " -yq"]
-}
+    # PROCESS SPAWNING:
+    def startProcess(self, params):
+        status = subprocess.call(params)
+        exit(status)
 
-cmd = commands[operation]
+    def startCommand(self, cmd):
+        self.startProcess(self.commands[cmd])
 
+if __name__ == '__main__':
+    operation = sys.argv[1]
+    package = sys.argv[2]
+    act = Action(package)
+    act.startCommand(operation)
 
-# PROCESS SPAWNING:
-def startProcess(params):
-    status = subprocess.call(params)
-    exit(status)
-
-startProcess(cmd)

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -8,8 +8,7 @@ from PackageManager import PackageManager
 import os
 
 arch = "amd64"
-mainarch = os.uname().get(4)
-mainarch = mainarch if mainarch is not None else “”
+mainarch = os.uname().machine
 
 if mainarch == "aarch64":
     arch = "arm64"

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -8,11 +8,8 @@ from PackageManager import PackageManager
 import os
 
 arch = "amd64"
-try:
-    mainarch = os.uname()[4]
-except Exception as e:
-    mainarch = ""
-    print("mainarch Exception : {}".format(e))
+mainarch = os.uname().get(4)
+mainarch = mainarch if mainarch is not None else “”
 
 if mainarch == "aarch64":
     arch = "arm64"

--- a/src/PackageManager.py
+++ b/src/PackageManager.py
@@ -3,6 +3,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import GLib, Gio, Gtk
 import os, sys
+from Actions import Action
 
 
 class PackageManager:
@@ -16,12 +17,7 @@ class PackageManager:
         currentPath = os.path.dirname(os.path.abspath(__file__))
 
         # - Installation commands
-        self.installCommand = ["/usr/bin/pkexec", currentPath + "/Actions.py", "install", "--PACKAGE--"]
-        self.removeCommand = ["/usr/bin/pkexec", currentPath + "/Actions.py", "remove", "--PACKAGE--"]
-        self.makeDefaultCommand = ["/usr/bin/pkexec", currentPath + "/Actions.py", "make-default", "--PATH--"]
         self.autoAlternativeCommand = ["/usr/bin/pkexec", currentPath + "/Actions.py", "update-alternatives-auto"]
-        self.updateAndRemoveCommand = ["/usr/bin/pkexec", currentPath + "/Actions.py", "update-and-remove",
-                                       "--PACKAGE--"]
 
         # - Info commands:
         self.isInstalledCommand = ["dpkg", "-s", "--PACKAGE--"]
@@ -31,31 +27,21 @@ class PackageManager:
         self.findDefault()
 
     def install(self, packageObject):
-        installCommand = self.installCommand
-        installCommand[3] = packageObject["package"]
-
-        self.startProcess(installCommand)
+        act = Action(packageObject["package"])
+        act.startCommand("install")
 
         self.on_progress("%0", "Downloading")
 
     def set_as_default(self, packageObject):
-        makeDefaultCommand = self.makeDefaultCommand
-        makeDefaultCommand[3] = packageObject["path"]
-
-        self.startProcess(makeDefaultCommand)
+        act = Action(packageObject["path"])
+        act.startCommand("make-default")
 
     def uninstall(self, packageObject):
+        act = Action(packageObject["package"] + "*")
         if self.isDefault(packageObject):
-            updateAndRemoveCommand = self.updateAndRemoveCommand
-            updateAndRemoveCommand[3] = updateAndRemoveCommand[3].replace("--PACKAGE--", packageObject["package"] + "*")
-
-            self.startProcess(updateAndRemoveCommand)
+            act.startCommand("update-and-remove")
         else:
-            removeCommand = self.removeCommand
-            removeCommand[3] = packageObject["package"] + "*"
-
-            self.startProcess(removeCommand)
-
+            act.startCommand("remove")
 
     # CHECK BOOLEANS:
     def isInstalled(self, packageObject):


### PR DESCRIPTION
After I realised that the PackageManager class was creating a python subprocess to call into Actions.py. I refactored and rearchitectured the system to not use nested subprocesses and instead import Actions.py but still compatibility with the old system by using an if __name__ = "__main__" guard to do what the old version would have done if you had called Actions.py directly.